### PR TITLE
Python 3.12 Updates

### DIFF
--- a/docs/burin.rst
+++ b/docs/burin.rst
@@ -154,6 +154,8 @@ general purpose.
     disable
     error
     exception
+    get_handler_by_name
+    get_handler_names
     get_level_name
     get_level_names_mapping
     get_log_record_factory
@@ -214,6 +216,17 @@ customise the logger class used.
 .. autofunction:: get_logger_class
 
 .. autofunction:: set_logger_class
+
+~~~~~~~~
+Handlers
+~~~~~~~~
+
+These are top-level functions that can be used to get handler names or a
+specific handler by name if a name has be set on the handler.
+
+.. autofunction:: get_handler_by_name
+
+.. autofunction:: get_handler_names
 
 ~~~~~~~~~~~
 Log Records

--- a/docs/burin.rst
+++ b/docs/burin.rst
@@ -75,6 +75,23 @@ not.
     This differs slightly from :mod:`logging` where the attributes are directly
     on the module.
 
+.. attribute:: burin.config.logAsyncioTasks
+    :value: True
+
+    Whether :class:`asyncio.Task` names should be available for inclusion in
+    logs.  Whatever value is set for this will be automatically converted using
+    :func:`bool`.
+
+    .. note::
+
+        In Python 3.12 this was added to the standard :mod:`logging` module; it
+        is supported here for all versions of Python compatible with Burin
+        (including versions below 3.12).
+
+        However; names were added to :class:`asyncio.Task` objects in Python
+        3.8, so in Python 3.7 the *taskName* attribute on a log record will
+        always be **None**.
+
 .. attribute:: burin.config.logMultiprocessing
     :value: True
 

--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -1,0 +1,45 @@
+.. currentmodule:: burin
+
+=====================
+Filters and Filterers
+=====================
+
+Filters can be used to determine if specific log records should be logged or
+not, and also provide the ability to modify records during processing.
+
+Both :class:`BurinLogger` and :class:`BurinHandler` are subclasses of
+:class:`BurinFilterer`.  When processing a logging event all filter checks
+will be done on the record to determine if it should be logged.
+
+Custom filters can be created by subclassing :class:`BurinFilter` and
+overriding the :meth:`BurinFilter.filter` method to perform custom checks or
+modify log records in place during processing.
+
+-----------
+BurinFilter
+-----------
+
+The default :class:`BurinFilter` is based on :class:`logging.Filter` and
+should function identically to it; it is not a subclass of it though.
+
+.. autoclass:: BurinFilter
+    :members: filter
+
+-------------
+BurinFilterer
+-------------
+
+This is a base class that is subclassed by both :class:`BurinLogger` and
+:class:`BurinHandler` so that filtering functionality can be re-used in both.
+
+While this is based on the standard library :class:`logging.Filterer` it is not
+a subclass of it.
+
+.. note::
+
+    All methods of the :class:`BurinFilterer` with an *underscore_separated*
+    name also have a *camelCase* alias name which matches the names used in the
+    standard :mod:`logging` library.
+
+.. autoclass:: BurinFilterer
+    :members: add_filter, filter, remove_filter

--- a/docs/formatters.rst
+++ b/docs/formatters.rst
@@ -22,7 +22,6 @@ BurinFormatter
 The :class:`BurinFormatter` is derived from :class:`logging.Formatter` and
 should function identically in almost all use cases.
 
-
 .. note::
 
     All methods of the :class:`BurinFormatter` with an *underscore_separated*

--- a/docs/handlers.rst
+++ b/docs/handlers.rst
@@ -103,7 +103,8 @@ from.  This should not be used directly but instead can be inherited from to
 create custom handlers.
 
 .. autoclass:: BurinHandler
-    :members: close, create_lock, format, handle_error, set_level
+    :members: acquire, close, create_lock, flush, format, handle, handle_error,
+              release, set_formatter, set_level
 
     .. autoproperty:: name
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -92,6 +92,7 @@ issues.
     handlers
     formatters
     log_records
+    filters
     exceptions
 
 .. toctree::

--- a/docs/loggers.rst
+++ b/docs/loggers.rst
@@ -51,6 +51,7 @@ that is a full description of the class, it attributes, and methods.
     BurinLogger.exception
     BurinLogger.find_caller
     BurinLogger.get_child
+    BurinLogger.get_children
     BurinLogger.get_effective_level
     BurinLogger.handle
     BurinLogger.has_handlers
@@ -64,8 +65,8 @@ that is a full description of the class, it attributes, and methods.
 
 .. autoclass:: BurinLogger
     :members: add_handler, call_handlers, critical, debug, error, exception,
-              find_caller, get_child, get_effective_level, handle,
-              has_handlers, info, is_enabled_for, log, make_record,
+              find_caller, get_child, get_children, get_effective_level,
+              handle, has_handlers, info, is_enabled_for, log, make_record,
               remove_handler, set_level, warning
 
     .. autoproperty:: msgStyle

--- a/src/burin/__init__.py
+++ b/src/burin/__init__.py
@@ -16,6 +16,7 @@ from ._burin import (critical, debug, disable, error, exception, info, log,
                      shutdown, warning)
 from ._config import basic_config, basicConfig
 from ._exceptions import ConfigError, FactoryError, FormatError
+from ._filters import BurinFilter, BurinFilterer
 from ._formatters import BurinBufferingFormatter, BurinFormatter
 from ._handlers import (BurinBaseRotatingHandler, BurinBufferingHandler,
                         BurinDatagramHandler, BurinFileHandler, BurinHandler,
@@ -43,21 +44,21 @@ from ._warnings import capture_warnings, captureWarnings
 
 __all__ = ["critical", "debug", "disable", "error", "exception", "info", "log",
            "shutdown", "warning", "basic_config", "basicConfig", "ConfigError",
-           "FactoryError", "FormatError", "BurinBufferingFormatter",
-           "BurinFormatter", "BurinBaseRotatingHandler",
-           "BurinBufferingHandler", "BurinDatagramHandler", "BurinFileHandler",
-           "BurinHandler", "BurinHTTPHandler", "BurinMemoryHandler",
-           "BurinNTEventLogHandler", "BurinNullHandler", "BurinQueueHandler",
-           "BurinQueueListener", "BurinRotatingFileHandler",
-           "BurinSMTPHandler", "BurinSocketHandler", "BurinStreamHandler",
-           "BurinSyslogHandler", "BurinTimedRotatingFileHandler",
-           "BurinWatchedFileHandler", "CRITICAL", "DEBUG", "ERROR", "INFO",
-           "NOTSET", "WARNING", "get_level_name", "getLevelName",
-           "get_level_names_mapping", "getLevelNamesMapping",
-           "BurinBraceLogRecord", "BurinDollarLogRecord", "BurinLogRecord",
-           "BurinPercentLogRecord", "get_log_record_factory",
-           "getLogRecordFactory", "make_log_record", "makeLogRecord",
-           "set_log_record_factory", "setLogRecordFactory", "BurinLogger",
-           "BurinLoggerAdapter", "get_logger", "getLogger", "get_logger_class",
-           "getLoggerClass", "set_logger_class", "setLoggerClass", "config",
-           "capture_warnings", "captureWarnings"]
+           "FactoryError", "FormatError", "BurinFilter", "BurinFilterer",
+           "BurinBufferingFormatter", "BurinFormatter",
+           "BurinBaseRotatingHandler", "BurinBufferingHandler",
+           "BurinDatagramHandler", "BurinFileHandler", "BurinHandler",
+           "BurinHTTPHandler", "BurinMemoryHandler", "BurinNTEventLogHandler",
+           "BurinNullHandler", "BurinQueueHandler", "BurinQueueListener",
+           "BurinRotatingFileHandler", "BurinSMTPHandler",
+           "BurinSocketHandler", "BurinStreamHandler", "BurinSyslogHandler",
+           "BurinTimedRotatingFileHandler", "BurinWatchedFileHandler",
+           "CRITICAL", "DEBUG", "ERROR", "INFO", "NOTSET", "WARNING",
+           "get_level_name", "getLevelName", "get_level_names_mapping",
+           "getLevelNamesMapping", "BurinBraceLogRecord",
+           "BurinDollarLogRecord", "BurinLogRecord", "BurinPercentLogRecord",
+           "get_log_record_factory", "getLogRecordFactory", "make_log_record",
+           "makeLogRecord", "set_log_record_factory", "setLogRecordFactory",
+           "BurinLogger", "BurinLoggerAdapter", "get_logger", "getLogger",
+           "get_logger_class", "getLoggerClass", "set_logger_class",
+           "setLoggerClass", "config", "capture_warnings", "captureWarnings"]

--- a/src/burin/__init__.py
+++ b/src/burin/__init__.py
@@ -1,7 +1,7 @@
 """
 Burin Logging Package
 
-Copyright (c) 2022 William Foster with BSD 3-Clause License
+Copyright (c) 2024 William Foster with BSD 3-Clause License
 See included LICENSE file for details.
 """
 
@@ -26,7 +26,8 @@ from ._handlers import (BurinBaseRotatingHandler, BurinBufferingHandler,
                         BurinRotatingFileHandler, BurinSMTPHandler,
                         BurinSocketHandler, BurinStreamHandler,
                         BurinSyslogHandler, BurinTimedRotatingFileHandler,
-                        BurinWatchedFileHandler)
+                        BurinWatchedFileHandler, get_handler_by_name,
+                        getHandlerByName, get_handler_names, getHandlerNames)
 from ._log_levels import (CRITICAL, DEBUG, ERROR, INFO, NOTSET, WARNING,
                           get_level_name, getLevelName,
                           get_level_names_mapping, getLevelNamesMapping)
@@ -53,12 +54,14 @@ __all__ = ["critical", "debug", "disable", "error", "exception", "info", "log",
            "BurinRotatingFileHandler", "BurinSMTPHandler",
            "BurinSocketHandler", "BurinStreamHandler", "BurinSyslogHandler",
            "BurinTimedRotatingFileHandler", "BurinWatchedFileHandler",
-           "CRITICAL", "DEBUG", "ERROR", "INFO", "NOTSET", "WARNING",
-           "get_level_name", "getLevelName", "get_level_names_mapping",
-           "getLevelNamesMapping", "BurinBraceLogRecord",
-           "BurinDollarLogRecord", "BurinLogRecord", "BurinPercentLogRecord",
-           "get_log_record_factory", "getLogRecordFactory", "make_log_record",
-           "makeLogRecord", "set_log_record_factory", "setLogRecordFactory",
-           "BurinLogger", "BurinLoggerAdapter", "get_logger", "getLogger",
-           "get_logger_class", "getLoggerClass", "set_logger_class",
-           "setLoggerClass", "config", "capture_warnings", "captureWarnings"]
+           "get_handler_by_name", "getHandlerByName", "get_handler_names",
+           "getHandlerNames", "CRITICAL", "DEBUG", "ERROR", "INFO", "NOTSET",
+           "WARNING", "get_level_name", "getLevelName",
+           "get_level_names_mapping", "getLevelNamesMapping",
+           "BurinBraceLogRecord", "BurinDollarLogRecord", "BurinLogRecord",
+           "BurinPercentLogRecord", "get_log_record_factory",
+           "getLogRecordFactory", "make_log_record", "makeLogRecord",
+           "set_log_record_factory", "setLogRecordFactory", "BurinLogger",
+           "BurinLoggerAdapter", "get_logger", "getLogger", "get_logger_class",
+           "getLoggerClass", "set_logger_class", "setLoggerClass", "config",
+           "capture_warnings", "captureWarnings"]

--- a/src/burin/_filters/__init__.py
+++ b/src/burin/_filters/__init__.py
@@ -1,0 +1,13 @@
+"""
+Burin Filters
+
+Copyright (c) 2024 William Foster with BSD 3-Clause License
+See included LICENSE file for details.
+"""
+
+# Package contents
+from .filter import BurinFilter
+from .filterer import BurinFilterer
+
+
+__all__ = ["BurinFilter", "BurinFilterer"]

--- a/src/burin/_filters/filter.py
+++ b/src/burin/_filters/filter.py
@@ -1,0 +1,67 @@
+"""
+Burin Filter
+
+Copyright (c) 2024 William Foster with BSD 3-Clause License
+See included LICENSE file for details.
+
+This module has some portions based on the Python standard logging library
+which is under the following licenses:
+Copyright (c) 2001-2024 Python Software Foundation; All Rights Reserved
+Copyright (c) 2001-2022 Vinay Sajip. All Rights Reserved.
+See included LICENSE file for details.
+"""
+
+class BurinFilter:
+    """
+    A filter can be used to apply filtering or modification of log records.
+
+    .. note::
+
+        This functions identically to the standard library
+        :class:`logging.Filter` class.
+
+    The base filter by default will allow all events which are lower in the
+    logger hierarchy.
+    """
+
+    def __init__(self, name=""):
+        """
+        This creates the filter for the specified name.
+
+        The name of logger is used to allow only events from the specified
+        logger and all loggers lower in the hierarchy.  If this is an empty
+        string the all events are allowed.
+
+        :param name: The name of the logger to allow events from along with all
+                     other loggers lower in the hierarchy.  All events are
+                     allowed if this is an empty string.  (Default = '')
+        :type name: str
+        """
+
+        self.name = name
+        self.nameLength = len(name)
+
+    def filter(self, record):
+        """
+        Determines if the record should be logged.
+
+        .. note::
+
+            If you are subclassing :class:`BurinFilter` and intend to modify
+            the log record then the modified record should also be returned.
+            The :class:`BurinFilterer` will then use the modified record
+            for all further processing and return it to the original caller.
+
+        :param record: The record to check.
+        :type record: BurinLogRecord
+        :returns: Whether the record should be logged or not.
+        :rtype: bool
+        """
+
+        if self.nameLength == 0 or (self.name == record.name):
+            return True
+
+        if not record.name.startswith(self.name):
+            return False
+
+        return record.name[self.nameLength] == "."

--- a/src/burin/_filters/filterer.py
+++ b/src/burin/_filters/filterer.py
@@ -1,0 +1,113 @@
+"""
+Burin Filterer
+
+Copyright (c) 2024 William Foster with BSD 3-Clause License
+See included LICENSE file for details.
+
+This module has some portions based on the Python standard logging library
+which is under the following licenses:
+Copyright (c) 2001-2024 Python Software Foundation; All Rights Reserved
+Copyright (c) 2001-2022 Vinay Sajip. All Rights Reserved.
+See included LICENSE file for details.
+"""
+
+from .._log_records import BurinLogRecord
+
+class BurinFilterer:
+    """
+    A base class for loggers and handlers to allow common code for filtering.
+
+    .. note::
+
+        This works identically to the :class:`logging.Filterer` in Python 3.12.
+        The class is recreated in Burin to simplify allowing the
+        :meth:`BurinFilterer.filter` method to return a log record.  This was
+        added to the standard library in 3.12 and is supported here for all
+        versions of Python compatible with Burin (including versions below
+        3.12).
+    """
+
+    def __init__(self):
+        """
+        Initializes the filterer with an empty list of filters.
+        """
+
+        self.filters = []
+
+    def add_filter(self, filter):  # noqa: A002
+        """
+        Adds the specified filter to the the list of filters.
+
+        :param filter: The filter to add to this filterer instance.
+        :type filter: BurinFilter
+        """
+
+        if filter not in self.filters:
+            self.filters.append(filter)
+
+    def filter(self, record):
+        """
+        Determine if a record is loggable according to all filters.
+
+        All filters are checked in the order that they were added using the
+        :meth:`BurinFilterer.add_filter` method.  If any filter returns
+        **False** the record will not be logged.
+
+        If a filter returns a log record instance then that instance will be
+        used for all further processing.
+
+        If none of the filters return **False** then a log record will be
+        returned.  If any filters returned an instance of a log record then the
+        returned record will be the last instance that was returned by a
+        filter.
+
+        However if any filter does return a **False** value then this method
+        will also return a false value.
+
+        .. note::
+
+            In Python 3.12 the ability for a filterer to return a record was
+            added to the standard library; it is supported here for all
+            versions of Python compatible with Burin (including versions below
+            3.12).
+
+        :param record: The log record instance to check.
+        :type record: BurinLogRecord
+        :returns: An instance of the record if it should be logged or **False**
+                  if it shouldn't.  If any filters modified the record or
+                  returned an different instance of a record then that is what
+                  will be returned here.  It should be used for all further
+                  processing and handling of the log record event.
+        :rtype: BurinLogRecord | False
+        """
+
+        for eachFilter in self.filters:
+            # Use the filter method if available, if not just use the filter
+            # itself as a callable
+            filterResult = eachFilter.filter(record) if hasattr(eachFilter, "filter") else eachFilter(record)
+
+            # If any filter returns False then stop checking immediately
+            if not filterResult:
+                return False
+
+            # If the filter returned a log record instance then use that
+            if isinstance(filterResult, BurinLogRecord):
+                record = filterResult
+
+        # If no filter returned False then return the record instance we have
+        return record
+
+    def remove_filter(self, filter):  # noqa: A002
+        """
+        Removes the specified filter from the list of filters
+
+        :param filter: The filter to remove from this filterer instance.
+        :type filter: BurinFilter
+        """
+
+        if filter in self.filters:
+            self.filters.remove(filter)
+
+    # Aliases for better compatibility to replace standard library logging
+    addFilter = add_filter
+    removeFilter = remove_filter

--- a/src/burin/_filters/filterer.py
+++ b/src/burin/_filters/filterer.py
@@ -78,7 +78,7 @@ class BurinFilterer:
                   returned an different instance of a record then that is what
                   will be returned here.  It should be used for all further
                   processing and handling of the log record event.
-        :rtype: BurinLogRecord | False
+        :rtype: BurinLogRecord | bool
         """
 
         for eachFilter in self.filters:

--- a/src/burin/_formatters/formatter.py
+++ b/src/burin/_formatters/formatter.py
@@ -110,6 +110,17 @@ class BurinFormatter(Formatter):
         Time in milliseconds from when the log record was created since the
         Burin package was loaded.
 
+    taskName
+        Asyncio task name.
+
+        .. note::
+            In Python 3.12 this was added to the standard library; it is
+            supported here for all versions of Python compatible with Burin
+            (including versions below 3.12).
+
+            However; this will always be **None** in Python 3.7 as Task names
+            were added in Python 3.8.
+
     thread
         Thread Id
 

--- a/src/burin/_handlers/__init__.py
+++ b/src/burin/_handlers/__init__.py
@@ -1,7 +1,7 @@
 """
 Burin Handlers
 
-Copyright (c) 2022 William Foster with BSD 3-Clause License
+Copyright (c) 2024 William Foster with BSD 3-Clause License
 See included LICENSE file for details.
 """
 
@@ -32,12 +32,41 @@ from .stream_handler import BurinStreamHandler
 from .syslog_handler import BurinSyslogHandler
 from .timed_rotating_file_handler import BurinTimedRotatingFileHandler
 from .watched_file_handler import BurinWatchedFileHandler
-from ._references import _handlerList
+from ._references import _handlers, _handlerList
 from ._stderr_handler import _BurinStderrHandler
 
 
 # The last resort if no other handlers are set
 lastResort = _BurinStderrHandler(WARNING)
+
+def get_handler_by_name(name):
+    """
+    Gets a handler with the specified name.
+
+    If no handler exists with the name then **None** is returned.
+
+    :param name: The name of the handler to get.
+    :type name: str
+    :returns: The handler with the specified name or **None** if it doesn't
+              exist.
+    :rtype: BurinHandler | None
+    """
+
+    return _handlers.get(name)
+
+def get_handler_names():
+    """
+    Gets all known handler names as an immutable set.
+
+    :returns: A frozenset of the handler names.
+    :rtype: frozenset
+    """
+
+    return frozenset(set(_handlers.keys()))
+
+# Aliases for better compatibility to replace standard library logging
+getHandlerByName = get_handler_by_name
+getHandlerNames = get_handler_names
 
 
 __all__ = ["DEFAULT_HTTP_LOGGING_PORT", "DEFAULT_SOAP_LOGGING_PORT",
@@ -49,7 +78,8 @@ __all__ = ["DEFAULT_HTTP_LOGGING_PORT", "DEFAULT_SOAP_LOGGING_PORT",
            "BurinQueueListener", "BurinRotatingFileHandler", "BurinSMTPHandler",
            "BurinSocketHandler", "BurinStreamHandler", "BurinSyslogHandler",
            "BurinTimedRotatingFileHandler", "BurinWatchedFileHandler",
-           "lastResort"]
+           "lastResort", "get_handler_by_name", "getHandlerByName",
+           "get_handler_names", "getHandlerNames"]
 
 
 # Clean up some things that aren't part of this package

--- a/src/burin/_handlers/handler.py
+++ b/src/burin/_handlers/handler.py
@@ -198,7 +198,7 @@ class BurinHandler(BurinFilterer):
         :type record: BurinLogRecord
         :returns: An instance of the record that was emitted, or **False** if
                   the record was not emitted.
-        :rtype: BurinLogRecord | False
+        :rtype: BurinLogRecord | bool
         """
 
         filterResult = self.filter(record)

--- a/src/burin/_handlers/handler.py
+++ b/src/burin/_handlers/handler.py
@@ -72,8 +72,6 @@ class BurinHandler(BurinFilterer):
     def name(self):
         """
         The name of the handler.
-
-        This is primarily used for an internal library reference map.
         """
         return self._name
 

--- a/src/burin/_loggers/__init__.py
+++ b/src/burin/_loggers/__init__.py
@@ -1,7 +1,7 @@
 """
 Burin Loggers and Manager
 
-Copyright (c) 2022 William Foster with BSD 3-Clause License
+Copyright (c) 2024 William Foster with BSD 3-Clause License
 See included LICENSE file for details.
 """
 
@@ -39,7 +39,6 @@ def set_logger_class(newClass):
     """
 
     BurinLogger.manager.loggerClass = newClass
-
 
 # Aliases for better compatibility to replace standard library logging
 getLoggerClass = get_logger_class

--- a/src/burin/_loggers/logger.py
+++ b/src/burin/_loggers/logger.py
@@ -410,6 +410,29 @@ class BurinLogger(BurinFilterer):
 
         return self.manager.get_logger(suffix, msgStyle=self.msgStyle)
 
+    def get_children(self):
+        """
+        Gets a set of loggers that are the immediate children of this logger.
+
+        .. note::
+
+            In Python 3.12 this method was changed on the standard
+            :class:`logging.Logger`; it is supported here for all versions
+            of Python compatible with Burin (including versions below 3.12).
+
+        :returns: A set of loggers that are direct children of this logger.
+        :rtype: set
+        """
+
+        hierLevel = 0 if self.root is self else len(self.name.split("."))
+
+        with _BurinLock:
+            loggerDict = self.manager.loggerDict
+            return {logger for name, logger in loggerDict.items()
+                    if isinstance(logger, BurinLogger) and
+                    logger.parent is self and
+                    len(logger.name.split(".")) == (hierLevel + 1)}
+
     def get_effective_level(self):
         """
         Gets the effective log level for this logger.
@@ -803,6 +826,7 @@ class BurinLogger(BurinFilterer):
     callHandlers = call_handlers
     findCaller = find_caller
     getChild = get_child
+    getChildren = get_children
     getEffectiveLevel = get_effective_level
     hasHandlers = has_handlers
     isEnabledFor = is_enabled_for

--- a/src/burin/_loggers/logger.py
+++ b/src/burin/_loggers/logger.py
@@ -43,8 +43,8 @@ else:
         # Intentionally raise an exception to get a frame from the exc_info
         try:
             raise Exception
-        except Exception:
-            return sys.exc_info()[2].tb_frame.f_back
+        except Exception as exc:
+            return exc.__traceback__.tb_frame.f_back
 
 # Setup method to check if frames are internal to Burin
 _srcDir = _internals["srcDir"]

--- a/src/burin/_state/__init__.py
+++ b/src/burin/_state/__init__.py
@@ -24,10 +24,36 @@ class _BurinConfig:
         Sets the initial configuration values.
         """
 
+        self.__logAsyncioTasks = True
         self.__logMultiprocessing = True
         self.__logProcesses = True
         self.__logThreads = True
         self.__raiseExceptions = True
+
+    @property
+    def logAsyncioTasks(self):
+        """
+        Whether asyncio task names should be available for inclusion in logs.
+
+        Whatever value is set for this will be automatically converted using
+        :func:`bool`.
+
+        .. note::
+
+            In Python 3.12 this was added to the standard :mod:`logging`
+            module; it is supported here for all versions of Python compatible
+            with Burin (including versions below 3.12).
+
+            However; names were added to :class:`asyncio.Task` objects in
+            Python 3.8, so in Python 3.7 the *taskName* attribute on a log
+            record will always be **None**.
+        """
+
+        return self.__logAsyncioTasks
+
+    @logAsyncioTasks.setter
+    def logAsyncioTasks(self, value):
+        self.__logAsyncioTasks = bool(value)
 
     @property
     def logMultiprocessing(self):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,278 @@
+"""
+Burin Filter Tests
+
+Copyright (c) 2024 William Foster with BSD 3-Clause License
+See included LICENSE file for details.
+"""
+
+# PyTest imports
+import pytest
+
+# Burin import
+import burin
+
+
+# Basic testing values
+testLevel = burin.INFO
+testLineNumber = 10
+testMessage = "This is a log message"
+testPathname = "/test/path"
+
+# Names for the test log records to create the hierarchy
+childName = "A.B"
+grandchildName = "A.B.C"
+parentName = "A"
+siblingName = "A.BB"
+similarName = "AA"
+
+@pytest.fixture
+def parent_record():
+    """
+    Creates a log record that would by at the top of a hierarchy.
+    """
+
+    return burin.BurinLogRecord(parentName, testLevel, testPathname,
+                                testLineNumber, testMessage, (), None)
+
+@pytest.fixture
+def child_record():
+    """
+    Creates a log record that is a child of a parent in the hierarchy.
+    """
+
+    return burin.BurinLogRecord(childName, testLevel, testPathname,
+                                testLineNumber, testMessage, (), None)
+
+@pytest.fixture
+def grandchild_record():
+    """
+    Creates a log record that is a grandchild of a parent in the hierarchy.
+    """
+
+    return burin.BurinLogRecord(grandchildName, testLevel, testPathname,
+                                testLineNumber, testMessage, (), None)
+
+@pytest.fixture
+def sibling_record():
+    """
+    Creates a log record that is a sibling of a child in the hierarchy.
+    """
+
+    return burin.BurinLogRecord(siblingName, testLevel, testPathname,
+                                testLineNumber, testMessage, (), None)
+
+@pytest.fixture
+def similar_record():
+    """
+    Creates a log record that is a similar to the parent in the hierarchy.
+    """
+
+    return burin.BurinLogRecord(similarName, testLevel, testPathname,
+                                testLineNumber, testMessage, (), None)
+
+@pytest.fixture
+def empty_filter():
+    """
+    Creates a filter that allows all records.
+    """
+
+    return burin.BurinFilter()
+
+@pytest.fixture
+def parent_filter():
+    """
+    Creates a filter that only allows a parent and lower hierarchical records.
+    """
+
+    return burin.BurinFilter(parentName)
+
+@pytest.fixture
+def child_filter():
+    """
+    Creates a filter that only allows a child and lower hierarchical records.
+    """
+
+    return burin.BurinFilter(childName)
+
+
+class TestFilter:
+    """
+    Tests the default filter class.
+    """
+
+    def test_empty_filter(self, empty_filter, parent_record, child_record,
+                          grandchild_record, sibling_record, similar_record):
+        """
+        Tests that an empty filter string allows any log record.
+        """
+
+        assert empty_filter.filter(parent_record) is True
+        assert empty_filter.filter(child_record) is True
+        assert empty_filter.filter(grandchild_record) is True
+        assert empty_filter.filter(sibling_record) is True
+        assert empty_filter.filter(similar_record) is True
+
+    def test_parent_filter(self, parent_filter, parent_record, child_record,
+                           grandchild_record, sibling_record, similar_record):
+        """
+        Tests filtering records at the parent level.
+        """
+
+        assert parent_filter.filter(parent_record) is True
+        assert parent_filter.filter(child_record) is True
+        assert parent_filter.filter(grandchild_record) is True
+        assert parent_filter.filter(sibling_record) is True
+        assert parent_filter.filter(similar_record) is False
+
+    def test_child_filter(self, child_filter, parent_record, child_record,
+                          grandchild_record, sibling_record, similar_record):
+        """
+        Tests filtering records at the child level.
+        """
+
+        assert child_filter.filter(parent_record) is False
+        assert child_filter.filter(child_record) is True
+        assert child_filter.filter(grandchild_record) is True
+        assert child_filter.filter(sibling_record) is False
+        assert child_filter.filter(similar_record) is False
+
+
+@pytest.fixture
+def basic_filterer():
+    """
+    Creates a basic filterer instance.
+    """
+
+    return burin.BurinFilterer()
+
+
+class LineIncrementFilter(burin.BurinFilter):
+    """
+    Returns a new record instance with an incremented line number.
+
+    This is purely for testing modification filters within a filterer.
+    """
+
+    def filter(self, record):
+        """
+        Creates a new record instance with an incremented line number.
+
+        :param record: The record to alter.
+        :type record: BurinLogRecord
+        :returns: A new record instance with an incremented line number.
+        :rtype: BurinLogRecord
+        """
+
+        return burin.BurinLogRecord(record.name, record.levelno, record.pathname, record.lineno + 1,
+                                    record.msg, record.args,record.exc_info, record.funcName,
+                                    record.stack_info, **record.kwargs)
+
+
+class TestFilterer:
+    """
+    Tests the filterer base class used for loggers and handlers.
+    """
+
+    def test_add_filter(self, basic_filterer, empty_filter, parent_filter,
+                        child_filter):
+        """
+        Tests adding multiple filters.
+        """
+
+        testFilters = [empty_filter, parent_filter, child_filter]
+
+        for eachFilter in testFilters:
+            basic_filterer.add_filter(eachFilter)
+
+        assert len(basic_filterer.filters) == len(testFilters)
+
+        for i in range(len(testFilters)):
+            assert basic_filterer.filters[i] is testFilters[i]
+
+    def test_readd_filter(self, basic_filterer, empty_filter):
+        """
+        Tests that re-adding the same filter doesn't duplicate it in the list.
+        """
+
+        basic_filterer.add_filter(empty_filter)
+        basic_filterer.add_filter(empty_filter)
+
+        assert len(basic_filterer.filters) == 1
+        assert basic_filterer.filters[0] is empty_filter
+
+    def test_remove_filter(self, basic_filterer, empty_filter, parent_filter,
+                           child_filter):
+        """
+        Tests removing a filter.
+        """
+
+        testFilters = [empty_filter, parent_filter, child_filter]
+
+        for eachFilter in testFilters:
+            basic_filterer.add_filter(eachFilter)
+
+        assert len(basic_filterer.filters) == len(testFilters)
+
+        basic_filterer.remove_filter(parent_filter)
+
+        assert len(basic_filterer.filters) == (len(testFilters) - 1)
+        assert parent_filter not in basic_filterer.filters
+
+    def test_remove_non_present_filter(self, basic_filterer, empty_filter,
+                                       parent_filter):
+        """
+        Tests removing a filter not in filter list doesn't impact the list.
+        """
+
+        basic_filterer.add_filter(empty_filter)
+        basic_filterer.remove_filter(parent_filter)
+
+        assert len(basic_filterer.filters) == 1
+        assert basic_filterer.filters[0] is empty_filter
+
+    def test_single_filter_checks(self, basic_filterer, parent_filter,
+                                  parent_record, child_record,
+                                  grandchild_record, sibling_record,
+                                  similar_record):
+        """
+        Tests a single filter check with different records.
+        """
+
+        basic_filterer.add_filter(parent_filter)
+
+        assert basic_filterer.filter(parent_record) is parent_record
+        assert basic_filterer.filter(child_record) is child_record
+        assert basic_filterer.filter(grandchild_record) is grandchild_record
+        assert basic_filterer.filter(sibling_record) is sibling_record
+        assert basic_filterer.filter(similar_record) is False
+
+    def test_multi_filter_checks(self, basic_filterer, parent_filter,
+                                 child_filter, parent_record, child_record,
+                                 grandchild_record, sibling_record,
+                                 similar_record):
+        """
+        Tests multiple filter checks with different records.
+        """
+
+        basic_filterer.add_filter(parent_filter)
+        basic_filterer.add_filter(child_filter)
+
+        assert basic_filterer.filter(parent_record) is False
+        assert basic_filterer.filter(child_record) is child_record
+        assert basic_filterer.filter(grandchild_record) is grandchild_record
+        assert basic_filterer.filter(sibling_record) is False
+        assert basic_filterer.filter(similar_record) is False
+
+    def test_modifying_filters(self, basic_filterer, parent_record):
+        """
+        Tests that modified records are returned through the filter process.
+        """
+
+        # Use two filters to ensure the record is progressively modified.
+        basic_filterer.add_filter(LineIncrementFilter())
+        basic_filterer.add_filter(LineIncrementFilter())
+
+        alteredRecord = basic_filterer.filter(parent_record)
+
+        assert alteredRecord is not parent_record
+        assert alteredRecord.lineno == (parent_record.lineno + 2)

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -31,7 +31,7 @@ def basic_record():
     """
 
     testRecord = burin.BurinLogRecord(testName, testLevel, testPathname,
-                                      testLineNumber, testMessage, None, None)
+                                      testLineNumber, testMessage, (), None)
     testRecord.message = testRecord.get_message()
     return testRecord
 

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -308,7 +308,7 @@ class TestBurinDollarStyle:
 
 
 @pytest.fixture
-def test_log_record():
+def sample_log_record():
     """
     Create a generic log record for formatter testing.
     """
@@ -360,102 +360,102 @@ class TestBurinFormatter:
         for styleKey, styleClass in formatterStyles.items():
             assert isinstance(burin.BurinFormatter(style=styleKey)._style, styleClass)
 
-    def test_formatter_no_validation(self, test_log_record):
+    def test_formatter_no_validation(self, sample_log_record):
         """
         Tests the a formatter will instantiate and work with no validation.
         """
 
         # Clear test stack and exception information as it isn't desired here
-        test_log_record.exc_info = None
-        test_log_record.stack_info = None
+        sample_log_record.exc_info = None
+        sample_log_record.stack_info = None
 
         recordFormat = "{message}"
 
         testFormatter = burin.BurinFormatter(recordFormat, style="{", validate=False)
 
-        assert testFormatter.format(test_log_record) == test_log_record.msg
+        assert testFormatter.format(sample_log_record) == sample_log_record.msg
 
-    def test_formatter_format_time_default(self, test_log_record):
+    def test_formatter_format_time_default(self, sample_log_record):
         """
         Tests formatting time from a log record using the default time format.
         """
 
         # Get the log record time into a string based on the default format
-        recordCreationTime = time.localtime(test_log_record.created)
+        recordCreationTime = time.localtime(sample_log_record.created)
         recordTimeText = time.strftime(burin.BurinFormatter.default_time_format, recordCreationTime)
-        recordTimeText += f",{test_log_record.msecs:0=3.0f}"
+        recordTimeText += f",{sample_log_record.msecs:0=3.0f}"
 
         testFormatter = burin.BurinFormatter()
 
-        assert testFormatter.formatTime(test_log_record) == recordTimeText
+        assert testFormatter.formatTime(sample_log_record) == recordTimeText
 
-    def test_formatter_format_time(self, test_log_record):
+    def test_formatter_format_time(self, sample_log_record):
         """
         Tests formatting time from a log record using a custom format.
         """
 
         dateTimeFormat = "%A %B %d, %I:%M:%S %p"
-        recordTimeText = time.strftime(dateTimeFormat, time.localtime(test_log_record.created))
+        recordTimeText = time.strftime(dateTimeFormat, time.localtime(sample_log_record.created))
 
         testFormatter = burin.BurinFormatter()
 
-        assert testFormatter.formatTime(test_log_record, dateTimeFormat) == recordTimeText
+        assert testFormatter.formatTime(sample_log_record, dateTimeFormat) == recordTimeText
 
-    def test_formatter_all_fields(self, test_log_record):
+    def test_formatter_all_fields(self, sample_log_record):
         """
         Tests formatting a record with all fields in the format string.
         """
 
         # Clear test stack and exception information as it isn't desired here
-        test_log_record.exc_info = None
-        test_log_record.stack_info = None
+        sample_log_record.exc_info = None
+        sample_log_record.stack_info = None
 
         dateTimeFormat = "%A %B %d, %I:%M:%S %p"
         recordFormat = ("{asctime} - {created} - {filename} - {funcName} - {levelname} - {levelno} - {lineno} - "
                         "{message} - {module} - {msecs} - {name} - {pathname} - {process} - {processName} - "
-                        "{relativeCreated} - {thread} - {threadName}")
+                        "{relativeCreated} - {taskName} - {thread} - {threadName}")
 
         # Get a comparison for the record text
-        recordTimeText = time.strftime(dateTimeFormat, time.localtime(test_log_record.created))
-        recordText = recordFormat.format(asctime=recordTimeText, message=test_log_record.msg,
-                                         **test_log_record.__dict__)
+        recordTimeText = time.strftime(dateTimeFormat, time.localtime(sample_log_record.created))
+        recordText = recordFormat.format(asctime=recordTimeText, message=sample_log_record.msg,
+                                         **sample_log_record.__dict__)
 
         testFormatter = burin.BurinFormatter(recordFormat, dateTimeFormat, "{")
 
-        assert testFormatter.format(test_log_record) == recordText
+        assert testFormatter.format(sample_log_record) == recordText
 
-    def test_formatter_defaults(self, test_log_record):
+    def test_formatter_defaults(self, sample_log_record):
         """
         Tests formatting defaults are inserted into the message properly.
         """
 
         # Clear test stack and exception information as it isn't desired here
-        test_log_record.exc_info = None
-        test_log_record.stack_info = None
+        sample_log_record.exc_info = None
+        sample_log_record.stack_info = None
 
         formatDefaults = {"test": "Pass"}
 
-        recordText = f"{test_log_record.msg} :: {formatDefaults['test']}"
+        recordText = f"{sample_log_record.msg} :: {formatDefaults['test']}"
 
         recordFormat = "{message} :: {test}"
         testFormatter = burin.BurinFormatter(recordFormat, style="{", defaults=formatDefaults)
 
-        assert testFormatter.format(test_log_record) == recordText
+        assert testFormatter.format(sample_log_record) == recordText
 
-    def test_formatter_exception_stack_info(self, test_log_record):
+    def test_formatter_exception_stack_info(self, sample_log_record):
         """
         Tests formatting a record with exception and stack information.
         """
 
         # Get the comparison text for the formatted record
-        recordText = f"{test_log_record.msg}"
-        recordText += f"\n{burin.BurinFormatter.format_exception(None, test_log_record.exc_info)}"
-        recordText += f"\n{test_log_record.stack_info}"
+        recordText = f"{sample_log_record.msg}"
+        recordText += f"\n{burin.BurinFormatter.format_exception(None, sample_log_record.exc_info)}"
+        recordText += f"\n{sample_log_record.stack_info}"
 
         recordFormat = "{message}"
         testFormatter = burin.BurinFormatter(recordFormat, style="{")
 
-        assert testFormatter.format(test_log_record) == recordText
+        assert testFormatter.format(sample_log_record) == recordText
 
 
 class TestBurinBufferingFormatter:


### PR DESCRIPTION
Integrate changes from Python 3.12 where appropriate and add fixes/changes to be available with all supported Python versions for Burin.

Closes #9